### PR TITLE
Fix "Unicode-objects must be encoded before hashing" crash in openid view

### DIFF
--- a/djangopeople/django_openidauth/tests/test_views.py
+++ b/djangopeople/django_openidauth/tests/test_views.py
@@ -1,0 +1,9 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from ..views import _make_hash
+
+
+class TestUtils(TestCase):
+    def test_make_hash(self):
+        self.assertEqual(_make_hash('add', User(id=432), 'xxx'), 'd1d20d6ade210ab64237397adb2a4a14')

--- a/djangopeople/django_openidauth/views.py
+++ b/djangopeople/django_openidauth/views.py
@@ -15,9 +15,9 @@ from .models import UserOpenID, associate_openid, unassociate_openid
 
 
 def _make_hash(hash_type, user, openid):
-    return hashlib.md5('%s:%d:%s:%s' % (
+    return hashlib.md5(('%s:%d:%s:%s' % (
         hash_type, user.id, str(openid), settings.SECRET_KEY
-    )).hexdigest()
+    )).encode('utf8')).hexdigest()
 
 
 @login_required


### PR DESCRIPTION
```
TypeError: Unicode-objects must be encoded before hashing
...
  File "djangopeople/django_openidauth/views.py", line 52, in associations
    for openid in associated_openids
  File "djangopeople/django_openidauth/views.py", line 52, in <listcomp>
    for openid in associated_openids
  File "djangopeople/django_openidauth/views.py", line 19, in _make_hash
    hash_type, user.id, str(openid), settings.SECRET_KEY
```