### PR TITLE
Travis - test on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
As per [their blog post](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) they're making it the new default, best to be ahead of the curve.